### PR TITLE
Fixed truncateStringAttributeValue

### DIFF
--- a/index.js
+++ b/index.js
@@ -337,6 +337,7 @@ class PrettyJSON extends HTMLElement {
     const isArray = Array.isArray(object);
     const objectKeyName = this.getAttribute("key");
     const expand = this.#expandAttributeValue;
+    const truncateString = this.#truncateStringAttributeValue; // Get the truncate string attribute value
 
     const container = this.#createContainer();
     container.classList.add(isArray ? "array" : "object");
@@ -395,6 +396,7 @@ class PrettyJSON extends HTMLElement {
       const prettyJsonElement = document.createElement("pretty-json");
       prettyJsonElement.textContent = JSON.stringify(value);
       prettyJsonElement.setAttribute("expand", String(expand - 1));
+      prettyJsonElement.setAttribute("truncate-string", String(truncateString)); // Set the truncate-string attribute
       prettyJsonElement.setAttribute("key", key);
       container.appendChild(prettyJsonElement);
     });


### PR DESCRIPTION
Fix truncate string issue for nested elements in PrettyJSON component.

truncate-string="number" was not working for nested elements, thus breaking the layout.

Fixes #30 


